### PR TITLE
Create the skeleton page for NApps best practices

### DIFF
--- a/napps/best_practices.md
+++ b/napps/best_practices.md
@@ -7,3 +7,10 @@ Best practices for Kytos NApp development
 
 Use of storehouse
 -----------------
+
+When using the filesystem backend there is no
+guarantee that the order two write operations
+are called will be the order they are executed.
+To ensure that, it is advised the use of thread
+locks, so one write operation is called only after
+the previous one returns.

--- a/napps/best_practices.md
+++ b/napps/best_practices.md
@@ -1,0 +1,9 @@
+---
+title: Best practices
+parent: NApps
+---
+Best practices for Kytos NApp development
+=========================================
+
+Use of storehouse
+-----------------

--- a/napps/napps.md
+++ b/napps/napps.md
@@ -1,0 +1,4 @@
+---
+has_children: true
+title: NApps
+---


### PR DESCRIPTION
Fixes #9

Just the skeleton of a page for best practices when developing a NApp.
Other pages for NApps development can also be created based on it.