### PR TITLE
Fixed typo in a goal 3 title

### DIFF
--- a/releases/2021.1/2022.1.md
+++ b/releases/2021.1/2022.1.md
@@ -86,7 +86,7 @@ Switch Vendor                        | Switch          | Firmware version       
 
 [kytos-end-to-end-tests](https://github.com/amlight/kytos-end-to-end-tests) suite was only run for OVS in this release. In the future, other switch target platforms might be supported by this test suite.
 
-### 3. Perform network stress terms to verify performance, reliability an overall stability
+### 3. Perform network stress terms to verify performance, reliability and overall stability
 
 In order to verify Kytos-ng performance, reliability, and overall stability, we designed a set of experiments considering different scenarios: batch creation of hundreds of L2VPNs (i.e., mef_eline's EVC), Kytos-ng execution in disruptive environments (i.e., considering link disruption, switch connection reset, controller failures), long term Kytos-ng execution. Each experiment was repeated 10 times (except the long-term Kytos-ng execution), and we analyze the results considering the confidence interval of 95%.
 


### PR DESCRIPTION
Just realized this "an" that was supposed to be an "and" when I was extracting the goals for another report. 