### PR TITLE
Added recommended ulimit settings page link

### DIFF
--- a/napps/mongodb_notes.md
+++ b/napps/mongodb_notes.md
@@ -49,6 +49,7 @@ MongoDB University has some great free watch on-demand courses, if you're intere
 ### Production notes
 
 - [Recommended file systems](https://www.mongodb.com/docs/manual/administration/production-notes/#kernel-and-file-systems)
+- [Recommended ulimit settings](https://www.mongodb.com/docs/v5.0/reference/ulimit/#recommended-ulimit-settings)
 - [Back Up and Restore with MongoDB Tools](https://www.mongodb.com/docs/manual/tutorial/backup-and-restore-tools/)
 - [Allocate Sufficient RAM and CPU](https://www.mongodb.com/docs/manual/administration/production-notes/#std-label-prod-notes-ram)
 - [Authentication](https://www.mongodb.com/docs/manual/core/authentication/)


### PR DESCRIPTION

Added recommended ulimit settings page link. cc'ing @italovalcy for his info. 

@italovalcy, the recommended `ulimit` settings it's probably a good start, and something to make sure we've got covered for the containers when deploying to prod. I've also noticed in practice (when running some benchmarks and local stress tests) that not only `mongod` but also the client has to set  the `ulimit` values accordingly, the connection pool itself works but it still assumes that ulimit values are also compatible as has room for more file descriptors if needed. Maybe we can use this page as an start as the deployment documentation is created internally later on, wdyt? 