### PR TITLE
Removed storehouse API docs

### DIFF
--- a/api/storehouse.md
+++ b/api/storehouse.md
@@ -1,7 +1,0 @@
----
-repository: storehouse
-layout: api
-title: Storehouse API
-parent: API
----
-{% include api.html %}


### PR DESCRIPTION
Nuked storehouse API docs from kytos-ng.github.io docs since it's being deprecated