### PR TITLE
Froze release PR/issues stats until Aug 22, 2022

### DIFF
--- a/releases/2022.2/2022.2.md
+++ b/releases/2022.2/2022.2.md
@@ -168,8 +168,8 @@ An overview about Kytos-ng unit and end-to-end tests coverage is available on th
 
 In the [kytos-ng](https://github.com/kytos-ng) organization, during the period of this release from February 2022 to August 2022:
 
-- [217 pull requests were merged](https://github.com/search?q=org%3Akytos-ng+is%3Apr+is%3Aclosed+merged%3A2022-02-11..2022-08-31&type=Issues)
-- [87 issues were closed](https://github.com/search?q=org%3Akytos-ng+is%3Aissue+label%3A2022.2+is%3Aclosed&type=Issues)
+- [219 pull requests were merged](https://github.com/search?q=org%3Akytos-ng+is%3Apr+is%3Aclosed+merged%3A2022-02-11..2022-08-22&type=Issues)
+- [88 issues were closed](https://github.com/search?q=org%3Akytos-ng+is%3Aissue+label%3A2022.2+closed%3A2022-02-11..2022-08-22&type=Issues)
 
 ## Kytos-ng Team
 


### PR DESCRIPTION
GH statistics filter for issues and PR were until Aug 31, 2022. This PR freezes these filters results until Aug 22, 2022. New patches could possibly land if major unexpected issues show up, that won't be accounted for in terms of general stats to simplify maintenance. If we need to take that into account too we'll review how stats should be reported in a next opportunity.  