### PR TITLE
Added `notified_up_at` internal reserved metadata

### DIFF
--- a/napps/metadata.md
+++ b/napps/metadata.md
@@ -63,11 +63,12 @@ Internal Metadata
 -----------------
 
 
-| Metadata              | Napp        | Object     | Type  | Description                                   | Date       | Used by                       |
-|-----------------------|-------------|------------|-------|-----------------------------------------------|------------|-------------------------------|
-| liveness_status       | topology    | link       | str   | Link's liveness status  up\|down              | 06.30.22   | topology, core                |
-| last_status_change    | topology    | link       | float | Link's last status change timestamp           | 06.30.22   | topology                      |
-| last_status_is_active | topology    | link       | bool  | Whether Link's last status is active or not   | 06.30.22   | topology                      |
+| Metadata              | Napp        | Object     | Type      | Description                                   | Date       | Used by                       |
+|-----------------------|-------------|------------|-----------|-----------------------------------------------|------------|-------------------------------|
+| liveness_status       | topology    | link       | str       | Link's liveness status  up\|down              | 06.30.22   | topology, core                |
+| last_status_change    | topology    | link       | float     | Link's last status change timestamp           | 06.30.22   | topology                      |
+| last_status_is_active | topology    | link       | bool      | Whether Link's last status is active or not   | 06.30.22   | topology                      |
+| notified_up_at        | topology    | link       | datetime  | Link's last notified up datetime              | 11.18.22   | topology                      |
 
 
 Usage examples


### PR DESCRIPTION
Added `notified_up_at` internal reserved metadata:

Related to https://github.com/kytos-ng/topology/pull/114

It turns out that only `last_status_is_active` and `last_status_change` weren't sufficient (enhancements mapped)