### PR TITLE
doc: Add kytos_stats spec 

### DIFF
--- a/api/kytos_stats.md
+++ b/api/kytos_stats.md
@@ -1,0 +1,7 @@
+---
+repository: kytos_stats
+layout: api
+title: Kytos stats API
+parent: API
+---
+{% include api.html %}


### PR DESCRIPTION
Related to  [issue #53 of `flow_stats](https://github.com/kytos-ng/flow_stats/issues/53)

### Summary

Add OpenAPI spec doc page for kytos_stats.