### PR TITLE
docs: included amlight/sdntrace on released napps table

### DIFF
--- a/releases/2024.1/2024.1.md
+++ b/releases/2024.1/2024.1.md
@@ -112,6 +112,7 @@ Project                                                             | Release We
 [kytos/pathfinder](https://github.com/kytos-ng/pathfinder)          | [kytos/pathfinder](https://github.com/kytos-ng/pathfinder/releases)
 [amlight/coloring](https://github.com/kytos-ng/coloring)            | [kytos-ng/coloring](https://github.com/kytos-ng/coloring/releases)
 [amlight/sdntrace_cp](https://github.com/kytos-ng/sdntrace_cp)      | [kytos-ng/sdntrace_cp](https://github.com/kytos-ng/sdntrace_cp/releases)
+[amlight/sdntrace](https://github.com/kytos-ng/sdntrace)            | [kytos-ng/sdntrace](https://github.com/kytos-ng/sdntrace/releases)
 [kytos/mef_eline](https://github.com/kytos-ng/mef_eline)            | [kytos/mef_eline](https://github.com/kytos-ng/mef_eline/releases)
 [kytos/of_multi_table](https://github.com/kytos-ng/of_multi_table)  | [kytos/of_multi_table](https://github.com/kytos-ng/of_multi_table/releases)
 [kytos/telemetry_int](https://github.com/kytos-ng/telemetry_int)    | [kytos/telemetry_int](https://github.com/kytos-ng/telemetry_int/releases)


### PR DESCRIPTION
### Summary

- Included amlight/sdntrace on released napps table. It was forgotten to be included on this table. 

### Local Tests

![20241003_111427](https://github.com/user-attachments/assets/964bdf31-a57e-43d4-ae32-590aace98d44)

