### PR TITLE
docs: included mef_eline `001_redeploy_set_queue.py` script

### DIFF
--- a/releases/2025.1/2025.1.md
+++ b/releases/2025.1/2025.1.md
@@ -89,6 +89,10 @@ If upgrading from prior versions, the following mandatory scripts need to be exe
 - [`001_update_default_queue.py`](https://github.com/kytos-ng/mef_eline/blob/master/scripts/db/2023.2.0/001_update_default_queue.py) can be used to update `queue_id` from `None` to `-1`, this was a change on prior versions, but this script hadn't been made available before.
 - [`000_retire_metadata.py`](https://github.com/kytos-ng/topology/blob/master/scripts/db/2025.2.0/000_retire_metadata.py) can be used to retire the `last_status_is_active`, `last_status_change`, and `notified_up_at` metadata from `links`, which are no longer in use.
 
+The following script is optional:
+
+- [`001_redeploy_set_queue.py`](https://github.com/kytos-ng/mef_eline/blob/master/scripts/console/2025.1.1/001_redeploy_set_queue.py) can be used to redeploy EVCs which have a QoS queue configured, `set_queue` action is now placed before the `output` action. On NoviFlow switches, internally the `set_queue` action was already reorder before the `output` action so it would work as one would expect.
+
 In addition, the following console scripts helpers can be used on demand (if a tag leak resource is identified) to fix potential missing tag allocations or deallocations:
 
 - [001_use_tags.py](https://github.com/kytos-ng/topology/blob/master/scripts/console/2023.2.0/001_use_tags.py)


### PR DESCRIPTION
Closes #85 

### Summary

This should only be merged when https://github.com/kytos-ng/mef_eline/pull/672 lands too

### Local Tests

It rendered correctly:

![20250626_114755](https://github.com/user-attachments/assets/78467746-efd4-4c85-9f3c-d9aa51837bb6)


### End-to-End Tests

N/A
