### PR TITLE
docs: augmented release notes 2025.1 with 000_liveness_deleted.py

### DIFF
--- a/releases/2025.1/2025.1.md
+++ b/releases/2025.1/2025.1.md
@@ -89,9 +89,10 @@ If upgrading from prior versions, the following mandatory scripts need to be exe
 - [`001_update_default_queue.py`](https://github.com/kytos-ng/mef_eline/blob/master/scripts/db/2023.2.0/001_update_default_queue.py) can be used to update `queue_id` from `None` to `-1`, this was a change on prior versions, but this script hadn't been made available before.
 - [`000_retire_metadata.py`](https://github.com/kytos-ng/topology/blob/master/scripts/db/2025.2.0/000_retire_metadata.py) can be used to retire the `last_status_is_active`, `last_status_change`, and `notified_up_at` metadata from `links`, which are no longer in use.
 
-The following script is optional:
+The following scripts are optional:
 
 - [`001_redeploy_set_queue.py`](https://github.com/kytos-ng/mef_eline/blob/master/scripts/console/2025.1.1/001_redeploy_set_queue.py) can be used to redeploy EVCs which have a QoS queue configured, `set_queue` action is now placed before the `output` action. On NoviFlow switches, internally the `set_queue` action was already reorder before the `output` action so it would work as one would expect.
+- [`000_liveness_deleted.py`](https://github.com/kytos-ng/of_lldp/blob/base/2025.1.1/scripts/db/2025.1.1/000_liveness_deleted.py) can be used to delete old non existent interface entries that have been hard deleted on topology but had link liveness enabled.
 
 In addition, the following console scripts helpers can be used on demand (if a tag leak resource is identified) to fix potential missing tag allocations or deallocations:
 


### PR DESCRIPTION
### Summary

- Augmented release notes 2025.1 with 000_liveness_deleted.py script

### Local Tests

Rendered as expected:

<img width="1051" height="461" alt="20250725_094842" src="https://github.com/user-attachments/assets/6837b6da-b35f-45c4-9fd9-db824d8e11e0" />


### End-to-End Tests

N/A
